### PR TITLE
Remove log.Printfs.

### DIFF
--- a/httpdown.go
+++ b/httpdown.go
@@ -349,7 +349,6 @@ func ListenAndServe(s *http.Server, hd *HTTP) error {
 	if err != nil {
 		return err
 	}
-	log.Printf("serving on http://%s/ with pid %d\n", s.Addr, os.Getpid())
 
 	waiterr := make(chan error, 1)
 	go func() {
@@ -367,7 +366,6 @@ func ListenAndServe(s *http.Server, hd *HTTP) error {
 		}
 	case s := <-signals:
 		signal.Stop(signals)
-		log.Printf("signal received: %s\n", s)
 		if err := hs.Stop(); err != nil {
 			return err
 		}
@@ -375,6 +373,5 @@ func ListenAndServe(s *http.Server, hd *HTTP) error {
 			return err
 		}
 	}
-	log.Println("exiting")
 	return nil
 }


### PR DESCRIPTION
For services (like github.com/letsencrypt/boulder/) that want to log everything
via syslog instead of stderr, and expect to receive only panics via stderr, it's
nice to be able to supress stderr logging. Some packages like
https://github.com/go-sql-driver/mysql do this by providing a way to override
the logger.

However, the logging in httpdown is minimal, and can be done by the caller
instead, so it seems better to just remove it.
